### PR TITLE
fix: update parking permit lookup for ada compliance

### DIFF
--- a/apps/parking-permit-lookup/index.html
+++ b/apps/parking-permit-lookup/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>Parking Permit Lookup</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/parking-permit-lookup/src/App.vue
+++ b/apps/parking-permit-lookup/src/App.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="min-h-screen flex flex-col">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-white focus:text-blue-700 focus:underline"
+      >Skip to main content</a
+    >
     <Header color="white" :open="menuOpen" @toggle="menuOpen = !menuOpen">
       <template v-slot:branding>
         <router-link to="/" class="w-full flex items-center">
@@ -8,7 +13,10 @@
         </router-link>
       </template>
     </Header>
-    <main class="flex-grow max-w-7xl w-full mx-auto px-4 mt-4">
+    <main
+      id="main-content"
+      class="flex-grow max-w-7xl w-full mx-auto px-4 mt-4"
+    >
       <router-view />
     </main>
     <Footer color="gray" variant="light">

--- a/apps/parking-permit-lookup/src/pages/Disclaimer.vue
+++ b/apps/parking-permit-lookup/src/pages/Disclaimer.vue
@@ -1,7 +1,7 @@
 <template>
   <article>
     <h1 class="text-2xl font-bold mb-8">Legal disclaimer</h1>
-    <main class="grid grid-cols-1 gap-3 prose">
+    <section class="grid grid-cols-1 gap-3 prose">
       <p>
         In an effort to make parking information more accessible, the Bureau of
         Transportation has created this application. Every effort has been made
@@ -35,7 +35,7 @@
         Computer Fraud and Abuse Act of 1984 and the National Information
         Infrastructure Protection Act of 1996.
       </p>
-    </main>
+    </section>
   </article>
 </template>
 

--- a/apps/parking-permit-lookup/src/pages/PermitLookup.vue
+++ b/apps/parking-permit-lookup/src/pages/PermitLookup.vue
@@ -10,7 +10,7 @@
         alt="PBOT Area Parking Permit Program logo"
       />
     </header>
-    <main class="max-w-xl flex flex-col space-y-4">
+    <section class="max-w-xl flex flex-col space-y-4">
       <i18n-t keypath="help" tag="p">
         <template v-slot:licenseFAQLink>
           <Anchor
@@ -28,6 +28,7 @@
       <form
         class="flex flex-col md:flex-row md:space-x-4 md:space-y-0 space-y-4"
         @submit.prevent="handleSubmit"
+        aria-label="Parking permit lookup"
       >
         <Input
           id="licensePlateInput"
@@ -79,12 +80,18 @@
           }"
           :disabled="isLoading || error"
         >
-          <div v-if="isLoading" class="flex items-center justify-center px-3">
+          <div
+            v-if="isLoading"
+            class="flex items-center justify-center px-3"
+            role="status"
+            aria-label="Loading"
+          >
             <svg
               class="animate-spin h-6 w-6"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <circle
                 class="opacity-25"
@@ -124,7 +131,7 @@
           </template>
         </i18n-t>
       </Message>
-    </main>
+    </section>
   </article>
 </template>
 


### PR DESCRIPTION
Updates page title to be relevant to app

Adds skip-to-main content setup for whole application

Changes inner main to section since there can only be one main tag

Changes PermitLookup.vue inner main to section. Adds aria-label to form. Update loading spinner container with label and role. Hides decorative spinning SVG from aria

ref: ess-1133