### PR TITLE
fix: run approve-builds for pnpm packages

### DIFF
--- a/.docker/apps/Dockerfile
+++ b/.docker/apps/Dockerfile
@@ -14,6 +14,7 @@ RUN npm install -g pnpm &&\
 
 WORKDIR /home/node/${WORKDIR}
 
+RUN pnpm approve-builds --all
 RUN pnpm --filter "{.}..." install && \
     pnpm --filter "{.}^..." build && \
     pnpm build --mode ${MODE}

--- a/.docker/services/Dockerfile
+++ b/.docker/services/Dockerfile
@@ -15,6 +15,7 @@ COPY . /home/node/
 
 WORKDIR /home/node/${WORKDIR}
 
+RUN pnpm approve-builds --all
 RUN pnpm --filter "{.}..." install
 RUN pnpm --filter "{.}..." build
 


### PR DESCRIPTION
newer version of pnpm require approving builds. Approve all for now to allow builds to proceed