### PR TITLE
fix: downgrade to pnpm 10

### DIFF
--- a/.docker/apps/Dockerfile
+++ b/.docker/apps/Dockerfile
@@ -9,14 +9,13 @@ WORKDIR /home/node/
 
 COPY . .
 
-RUN npm install -g pnpm &&\
+RUN npm install -g pnpm@10.28.2 &&\
     pnpm config set store-dir /home/node/.pnpm-store
 
 WORKDIR /home/node/${WORKDIR}
 
 
 RUN pnpm --filter "{.}..." install && \
-    pnpm approve-builds --all && \
     pnpm --filter "{.}^..." build && \
     pnpm build --mode ${MODE}
 

--- a/.docker/services/Dockerfile
+++ b/.docker/services/Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_ENV=ci
 
 COPY .docker/services/rootfs /
 
-RUN npm install -g pnpm &&\
+RUN npm install -g pnpm@10.28.2 &&\
     pnpm config set store-dir /home/node/.pnpm-store
 
 WORKDIR /home/node/
@@ -16,7 +16,6 @@ COPY . /home/node/
 WORKDIR /home/node/${WORKDIR}
 
 RUN pnpm --filter "{.}..." install
-RUN pnpm approve-builds --all
 RUN pnpm --filter "{.}..." build
 
 FROM node:22-bookworm-slim
@@ -27,7 +26,7 @@ ENV NODE_ENV=production
 
 COPY --from=builder /home/node /home/node
 
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@10.28.2 && \
     # remove any node_modules folders
     find /home/node/ -name "node_modules" -type d -prune -exec rm -rf '{}' +
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.pnpm-store
+node_modules
+**/.pnpm-store
+**/node_modules

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "PBOT applications relying on federated graphs",
   "author": "Mike McDonald <michael.mcdonald@portlandoregon.gov>",
   "license": "MIT",
+  "packageManager": "pnpm@10.28.2",
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/packages/actions/build/action.yaml
+++ b/packages/actions/build/action.yaml
@@ -20,7 +20,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        version: latest
+        version: 10.28.2
     - name: Set up builder
       shell: bash
       run: docker buildx create --use


### PR DESCRIPTION
pnpm 11 ignores package.json, so would need a bigger refactor to upgrade. For now, downgrade to the latest 10 minor version. Remove unnecessary approve-builds, and ignore node_modules and .pnpm-store from docker build