### PR TITLE
hotfix: remove permanent redirect from ingress

### DIFF
--- a/.github/workflows/stage-apps.yaml
+++ b/.github/workflows/stage-apps.yaml
@@ -119,9 +119,6 @@ jobs:
             values: |
               ingress:
                 enabled: true
-                annotations:
-                  nginx.ingress.kubernetes.io/permanent-redirect: "https://www.portland.gov/transportation/permitting/temporary-street-use-permitting-tsup"
-
                 hosts:
                   - host: pbotapps-test.portland.gov
                     paths:


### PR DESCRIPTION
bus reservation app is being reactivated. Remove redirect from test environment for testing